### PR TITLE
add tagger

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -212,6 +212,10 @@ repos:
     url: git@github.com:VEuPathDB/SiteSearchService.git
     branch: master
 
+  - dest: tagger
+    url: git@github.com:VEuPathDB/tagger.git
+    branch: qa
+
   - dest: TuningManager
     url: git@github.com:VEuPathDB/TuningManager.git
     branch: master
@@ -351,6 +355,7 @@ groups:
     repos:
       - EuPathGalaxy
       - OAuth2Server
+      - tagger
     includes:
       - irods
       - apiSite


### PR DESCRIPTION
@jbrestel My intent here is to have a new api-build-NN branch created in the tagger repo with the rest - but have that branch based off of the qa branch.  I _think_ this will accomplish that, but would like you to double check that it works that way with your branching process.